### PR TITLE
feat(endpoint-cache): use LRUCache from @aws-sdk

### DIFF
--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -17,7 +17,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {
-    "mnemonist": "0.38.3",
+    "@aws-sdk/lru-cache": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/endpoint-cache/src/EndpointCache.spec.ts
+++ b/packages/endpoint-cache/src/EndpointCache.spec.ts
@@ -1,9 +1,9 @@
-import LRUCache from "mnemonist/lru-cache";
+import { LRUCache } from "@aws-sdk/lru-cache";
 
 import { Endpoint } from "./Endpoint";
 import { EndpointCache } from "./EndpointCache";
 
-jest.mock("mnemonist/lru-cache");
+jest.mock("@aws-sdk/lru-cache");
 
 describe(EndpointCache.name, () => {
   let endpointCache;

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -81,9 +81,7 @@ export class EndpointCache {
    * @param {string} key
    */
   delete(key: string) {
-    // Replace with remove/delete call once support is added upstream
-    // Refs: https://github.com/Yomguithereal/mnemonist/issues/143
-    this.cache.set(key, []);
+    this.cache.delete(key);
   }
 
   /**
@@ -93,17 +91,7 @@ export class EndpointCache {
    * @returns {boolean}
    */
   has(key: string): boolean {
-    if (!this.cache.has(key)) {
-      return false;
-    }
-
-    // Remove call for peek, once remove/delete support is added upstream
-    // Refs: https://github.com/Yomguithereal/mnemonist/issues/143
-    const endpoints = this.cache.peek(key);
-    if (!endpoints) {
-      return false;
-    }
-    return endpoints.length > 0;
+    return this.cache.has(key);
   }
 
   /**

--- a/packages/endpoint-cache/src/EndpointCache.ts
+++ b/packages/endpoint-cache/src/EndpointCache.ts
@@ -1,4 +1,4 @@
-import LRUCache from "mnemonist/lru-cache";
+import { LRUCache } from "@aws-sdk/lru-cache";
 
 import { Endpoint } from "./Endpoint";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8260,13 +8260,6 @@ mkdirp@0.5.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-mnemonist@0.38.3:
-  version "0.38.3"
-  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.3.tgz#35ec79c1c1f4357cfda2fe264659c2775ccd7d9d"
-  integrity sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==
-  dependencies:
-    obliterator "^1.6.1"
-
 mocha@^8.0.1:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.3.2.tgz#53406f195fa86fbdebe71f8b1c6fb23221d69fcc"
@@ -8758,11 +8751,6 @@ object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
-
-obliterator@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
-  integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
 
 octokit-pagination-methods@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
### Issue
Internal JS-2621

### Description
Uses LRUCache from @aws-sdk/lru-cache instead of mnemonist

### Testing
Unit tests

### Additional context
PR will be posted upstream once `@aws-sdk/lru-cache` is merged in https://github.com/aws/aws-sdk-js-v3/pull/2406

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
