### PR TITLE
chore(deps): call postinstall-node-version-check in non clients

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
@@ -21,6 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",
@@ -21,6 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "buffer": "^5.6.0",
     "stream-browserify": "^3.0.0",
     "tslib": "^2.0.0"

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/chunked-blob-reader": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/sha256-tree-hash": "3.20.0",

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/body-checksum-browser",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/chunked-stream-reader-node": "3.20.0",
     "@aws-sdk/is-array-buffer": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/body-checksum-node",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/util-base64-browser": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/chunked-blob-reader-native",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/chunked-blob-reader",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/chunked-stream-reader-node",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/client-documentation-generator",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -20,6 +20,7 @@
     "typedocplugin"
   ],
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -24,6 +24,7 @@
     "typescript": "~4.3.2"
   },
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/signature-v4": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/config-resolver",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/core-packages-documentation-generator",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -20,6 +20,7 @@
     "typedocplugin"
   ],
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/credential-provider-cognito-identity",
   "version": "3.21.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/client-cognito-identity": "3.21.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/credential-provider-env": "3.20.0",
     "@aws-sdk/credential-provider-imds": "3.20.0",
     "@aws-sdk/credential-provider-web-identity": "3.20.0",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -24,6 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/credential-provider-env": "3.20.0",
     "@aws-sdk/credential-provider-imds": "3.20.0",
     "@aws-sdk/credential-provider-ini": "3.20.0",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -8,6 +8,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/credential-provider-ini": "3.20.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/shared-ini-file-loader": "3.20.0",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/client-sso": "3.21.0",
     "@aws-sdk/credential-provider-ini": "3.20.0",
     "@aws-sdk/property-provider": "3.20.0",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/endpoint-cache",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -17,6 +17,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "mnemonist": "0.38.3",
     "tslib": "^2.0.0"
   },

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/eventstream-handler-node",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/eventstream-marshaller": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-crypto/crc32": "^1.0.0",
     "@aws-sdk/types": "3.20.0",
     "@aws-sdk/util-hex-encoding": "3.20.0",

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/eventstream-marshaller",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/eventstream-marshaller": "3.20.0",
     "@aws-sdk/eventstream-serde-universal": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/eventstream-serde-browser",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/eventstream-serde-config-resolver",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/eventstream-marshaller": "3.20.0",
     "@aws-sdk/eventstream-serde-universal": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/eventstream-serde-node",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/eventstream-serde-universal",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/eventstream-marshaller": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -18,6 +18,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/querystring-builder": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -3,6 +3,7 @@
   "version": "3.20.0",
   "description": "Provides a way to make requests",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/hash-blob-browser",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/chunked-blob-reader": "3.20.0",
     "@aws-sdk/chunked-blob-reader-native": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -24,6 +24,7 @@
     "typescript": "~4.3.2"
   },
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "@aws-sdk/util-buffer-from": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/hash-node",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/hash-stream-node",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/invalid-dependency",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -23,6 +23,7 @@
   },
   "types": "./dist/types/index.d.ts",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "engines": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -3,6 +3,7 @@
   "version": "3.20.0",
   "description": "Provides a function for detecting if an argument is an ArrayBuffer",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/credential-provider-node": "3.21.0",
     "tslib": "^2.0.0"
   },

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/karma-credential-loader",
   "version": "3.21.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/md5-js",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -27,6 +27,7 @@
     "typescript": "~4.3.2"
   },
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "@aws-sdk/util-utf8-browser": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-apply-body-checksum",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/is-array-buffer": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "@aws-sdk/util-arn-parser": "3.20.0",

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-bucket-endpoint",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-content-length",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -23,6 +23,7 @@
     "typescript": "~4.3.2"
   },
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/config-resolver": "3.20.0",
     "@aws-sdk/endpoint-cache": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-endpoint-discovery",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-eventstream",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/middleware-header-default": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-expect-continue",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-header-default",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-host-header",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-location-constraint",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -18,6 +18,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-logger",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-retry",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/service-error-classification": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-api-gateway",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/signature-v4": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-ec2",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-glacier",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-machinelearning",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/signature-v4": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-rds",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-route53",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-s3-control",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/middleware-bucket-endpoint": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-s3",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "@aws-sdk/util-arn-parser": "3.20.0",

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-sqs",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "@aws-sdk/util-hex-encoding": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-sdk-sts",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -22,6 +22,7 @@
     "typescript": "~4.3.2"
   },
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/middleware-signing": "3.20.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -5,6 +5,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/eventstream-serde-browser": "3.20.0",
     "@aws-sdk/middleware-signing": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-serde",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -22,6 +22,7 @@
     "typescript": "~4.3.2"
   },
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/signature-v4": "3.20.0",

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-signing",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-ssec",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -19,6 +19,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -3,6 +3,7 @@
   "version": "3.20.0",
   "description": "Provides a means for composing multiple middleware functions into a single handler",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/middleware-user-agent",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -3,6 +3,7 @@
   "version": "3.20.0",
   "description": "Load config default values from ini config files and environmental variable",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -19,6 +19,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/property-provider": "3.20.0",
     "@aws-sdk/shared-ini-file-loader": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -19,6 +19,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/abort-controller": "3.20.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/querystring-builder": "3.20.0",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -3,6 +3,7 @@
   "version": "3.21.0",
   "description": "Provides a way to make requests",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/polly-request-presigner",
   "version": "3.21.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/signature-v4": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/property-provider",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/protocol-http",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "@aws-sdk/util-uri-escape": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/querystring-builder",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/querystring-parser",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/signature-v4": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "@aws-sdk/util-format-url": "3.20.0",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/s3-presigned-post",
   "version": "3.21.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/s3-request-presigner",
   "version": "3.21.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/protocol-http": "3.20.0",
     "@aws-sdk/signature-v4": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/service-error-classification",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/sha256-tree-hash",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/shared-ini-file-loader",
   "version": "3.20.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -12,6 +12,7 @@
     "typescript": "~4.3.2"
   },
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -19,6 +19,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/is-array-buffer": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "@aws-sdk/util-hex-encoding": "3.20.0",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/smithy-client",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/middleware-stack": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,6 +9,7 @@
     "typescript": "~4.3.2"
   },
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/url-parser",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/querystring-parser": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/util-buffer-from": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -3,6 +3,7 @@
   "description": "Determines the length of a request body in browsers",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -3,6 +3,7 @@
   "description": "Determines the length of a request body in node.js",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -24,6 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "engines": {

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -14,6 +14,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/is-array-buffer": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-buffer-from",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-create-request",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/middleware-stack": "3.20.0",
     "@aws-sdk/smithy-client": "3.20.0",
     "@aws-sdk/types": "3.20.0",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-dynamodb",
   "version": "3.21.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/querystring-builder": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-format-url",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -3,6 +3,7 @@
   "version": "3.20.0",
   "description": "Converts binary buffers to and from lowercase hexadecimal encoding",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -17,6 +17,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-locate-window",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -14,6 +14,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-uri-escape",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -18,6 +18,7 @@
   "license": "Apache-2.0",
   "react-native": "dist/es/index.native.js",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/types": "3.20.0",
     "bowser": "^2.11.0",
     "tslib": "^2.0.0"

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-user-agent-browser",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/node-config-provider": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-sdk/util-user-agent-node",
   "version": "3.20.0",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/util-buffer-from": "3.20.0",
     "tslib": "^2.0.0"
   },

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -14,6 +14,7 @@
     "typescript": "~4.3.2"
   },
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -3,6 +3,7 @@
   "version": "3.20.0",
   "description": "Shared utilities for client waiters for the AWS SDK",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "@aws-sdk/abort-controller": "3.20.0",
     "@aws-sdk/types": "3.20.0",
     "tslib": "^2.0.0"

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -3,6 +3,7 @@
   "version": "3.20.0",
   "description": "XML builder for the AWS SDK",
   "dependencies": {
+    "@aws-sdk/postinstall-node-version-check": "3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -12,6 +12,7 @@
     "typescript": "~4.3.2"
   },
   "scripts": {
+    "postinstall": "postinstall-node-version-check",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:es && yarn build:cjs",


### PR DESCRIPTION
### Issue
Internal JS-2727

### Description
Calls postinstall-node-version-check in non clients

### Testing
Tested in package abort-controller:

```console
$ fnm use 10
Using Node v10.24.1

$ yarn postinstall
yarn run v1.22.10
$ postinstall-node-version-check
(node:21294) NodeDeprecationWarning: The AWS SDK for JavaScript (v3) will
no longer support Node.js v10.24.1 as of January 1, 2022.
To continue receiving updates to AWS services, bug fixes, and security
updates please upgrade to Node.js 12.x or later.

More information can be found at: https://a.co/1l6FLnu
Done in 0.11s.

$ fnm use 12
Using Node v12.22.1

$ yarn postinstall
yarn run v1.22.10
$ postinstall-node-version-check
Done in 0.10s.
```

Testing of the util package done in https://github.com/aws/aws-sdk-js-v3/pull/2585

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
