### PR TITLE
fix(middleware-signing): update systemClockOffset on error

### DIFF
--- a/packages/middleware-signing/src/middleware.spec.ts
+++ b/packages/middleware-signing/src/middleware.spec.ts
@@ -89,4 +89,24 @@ describe(awsAuthMiddleware.name, () => {
       expect(getUpdatedSystemClockOffset).toHaveBeenCalledWith(dateHeader, mockSystemClockOffset);
     });
   });
+
+  it("should update systemClockOffset if error contains ServerTime", async () => {
+    const serverTime = new Date().toString();
+    const options = { ...mockOptions };
+    const signingHandler = awsAuthMiddleware(options)(mockNext, {});
+
+    const mockError = Object.assign(new Error("error"), { ServerTime: serverTime });
+    mockNext.mockRejectedValue(mockError);
+
+    try {
+      await signingHandler(mockSigningHandlerArgs);
+      fail(`should throw ${mockError}`);
+    } catch (error) {
+      expect(error).toStrictEqual(mockError);
+    }
+
+    expect(options.systemClockOffset).toBe(mockUpdatedSystemClockOffset);
+    expect(getUpdatedSystemClockOffset).toHaveBeenCalledTimes(1);
+    expect(getUpdatedSystemClockOffset).toHaveBeenCalledWith(serverTime, mockSystemClockOffset);
+  });
 });

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -28,6 +28,11 @@ export const awsAuthMiddleware =
           signingRegion: context["signing_region"],
           signingService: context["signing_service"],
         }),
+      }).catch((error) => {
+        if (error.ServerTime) {
+          options.systemClockOffset = getUpdatedSystemClockOffset(error.ServerTime, options.systemClockOffset);
+        }
+        throw error;
       });
 
       const { headers } = output.response as any;


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2208
This PR will be posted upstream once https://github.com/aws/aws-sdk-js-v3/pull/2681 is merged.

### Description
Updates systemClockOffset on error in middleware-signing

### Testing
* CI
* Updated system time offset to more than 15 minutes and verified that request is successful in the second retry

<details>
<summary>Code</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist/cjs/index.js";

const region = "us-east-1";
const client = new S3({ region, logger: console });
await client.listBuckets({});

```

</details>

<details>
<summary>Output</summary>

```console
{
  clientName: 'S3Client',
  commandName: 'ListBucketsCommand',
  input: {},
  output: {
    Buckets: [ [Object], [Object], [Object], [Object], [Object], [Object] ],
    Owner: {
      DisplayName: 'trivikr',
      ID: 'f36465be55e5435ccc8357d4857b23522cbf71100368115f086c017f5092617a'
    }
  },
  metadata: {
    httpStatusCode: 200,
    requestId: undefined,
    extendedRequestId: '/C9sJk2+qWrvZmgSC9L2VacyLS/QuTgZ0ICvtru4Kh0uc4ZUJBxfrVg+oDQj5r3Cnt+URA9fJJE=',
    cfId: undefined,
    attempts: 2,
    totalRetryDelay: 190
  }
}
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
