### PR TITLE
feat(script): add script prepare:artifacts:node

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "generate:defaults-mode-provider": "./scripts/generate-defaults-mode-provider/index.js",
     "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --no-private --yes",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
+    "prepare:artifacts:node": "node --es-module-specifier-resolution=node ./scripts/prepare-artifacts/node.mjs",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",
     "test:e2e": "yarn build:e2e && node ./tests/e2e/index.js",
     "test:functional": "jest --config tests/functional/jest.config.js",

--- a/scripts/prepare-artifacts/addBuildMetadataVersionSuffix.mjs
+++ b/scripts/prepare-artifacts/addBuildMetadataVersionSuffix.mjs
@@ -1,0 +1,12 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const addBuildMetadataVersionSuffix = async (workspacePaths, buildMetadata) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    const updatedPackageJson = { ...packageJson, version: `${packageJson.version}+${buildMetadata}` };
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-artifacts/addPreReleaseVersionSuffix.mjs
+++ b/scripts/prepare-artifacts/addPreReleaseVersionSuffix.mjs
@@ -1,0 +1,12 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const addPreReleaseVersionSuffix = async (workspacePaths, prereleaseTag) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    const updatedPackageJson = { ...packageJson, version: `${packageJson.version}-${prereleaseTag}` };
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-artifacts/deleteFilesWithExtension.mjs
+++ b/scripts/prepare-artifacts/deleteFilesWithExtension.mjs
@@ -1,0 +1,10 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execPromise = promisify(exec);
+
+export const deleteFilesWithExtension = async (workspacePaths, distFolderName, extension) => {
+  for (const workspacePath of workspacePaths) {
+    await execPromise(`find ${workspacePath}/${distFolderName} -name "${extension}" -type f -delete`);
+  }
+};

--- a/scripts/prepare-artifacts/deleteNotNodeDeps.mjs
+++ b/scripts/prepare-artifacts/deleteNotNodeDeps.mjs
@@ -12,8 +12,8 @@ export const deleteNotNodeDeps = async (workspacePaths) => {
         dependencies: Object.entries(packageJson.dependencies)
           .filter(
             ([key, value]) =>
-              !key.endsWith("browser") &&
-              !key.endsWith("native") &&
+              !key.endsWith("-browser") &&
+              !key.endsWith("-native") &&
               key !== "fetch-http-handler" &&
               key !== "chunked-blob-reader"
           )

--- a/scripts/prepare-artifacts/deleteNotNodeDeps.mjs
+++ b/scripts/prepare-artifacts/deleteNotNodeDeps.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const deleteNotNodeDeps = async (workspacePaths) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    const updatedPackageJson = {
+      ...packageJson,
+      ...(packageJson.dependencies && {
+        dependencies: Object.entries(packageJson.dependencies)
+          .filter(
+            ([key, value]) =>
+              !key.endsWith("browser") &&
+              !key.endsWith("native") &&
+              key !== "fetch-http-handler" &&
+              key !== "chunked-blob-reader"
+          )
+          .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {}),
+      }),
+    };
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-artifacts/deleteNotNodeEntriesInPackageJson.mjs
+++ b/scripts/prepare-artifacts/deleteNotNodeEntriesInPackageJson.mjs
@@ -1,0 +1,14 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const deleteNotNodeEntriesInPackageJson = async (workspacePaths) => {
+  for (const awsDepPath of workspacePaths) {
+    const packageJsonPath = join(awsDepPath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    ["types", "modules", "browser", "react-native"].forEach((keyToDelete) => {
+      delete packageJson[keyToDelete];
+    });
+    await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-artifacts/deleteNotNodeEntriesInPackageJson.mjs
+++ b/scripts/prepare-artifacts/deleteNotNodeEntriesInPackageJson.mjs
@@ -6,7 +6,7 @@ export const deleteNotNodeEntriesInPackageJson = async (workspacePaths) => {
     const packageJsonPath = join(awsDepPath, "package.json");
     const packageJsonBuffer = await readFile(packageJsonPath);
     const packageJson = JSON.parse(packageJsonBuffer.toString());
-    ["types", "modules", "browser", "react-native"].forEach((keyToDelete) => {
+    ["types", "module", "browser", "react-native"].forEach((keyToDelete) => {
       delete packageJson[keyToDelete];
     });
     await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2).concat(`\n`));

--- a/scripts/prepare-artifacts/node.mjs
+++ b/scripts/prepare-artifacts/node.mjs
@@ -3,6 +3,7 @@ import { getWorkspacePaths } from "../update-versions/getWorkspacePaths.mjs";
 import { updateVersions } from "../update-versions/updateVersions.mjs";
 import { addBuildMetadataVersionSuffix } from "./addBuildMetadataVersionSuffix.mjs";
 import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
+import { deleteNotNodeEntriesInPackageJson } from "./deleteNotNodeEntriesInPackageJson.mjs";
 import { updatePackageJsonVersion } from "./updatePackageJsonVersion.mjs";
 
 const workspacePaths = getWorkspacePaths();
@@ -21,3 +22,5 @@ await addPreReleaseVersionSuffix(workspacePaths, prereleaseTag);
 await addBuildMetadataVersionSuffix(workspacePaths, buildMetadata);
 
 updateVersions(getDepToCurrentVersionHash());
+
+await deleteNotNodeEntriesInPackageJson(workspacePaths);

--- a/scripts/prepare-artifacts/node.mjs
+++ b/scripts/prepare-artifacts/node.mjs
@@ -1,4 +1,6 @@
+import { getDepToCurrentVersionHash } from "../update-versions/getDepToCurrentVersionHash.mjs";
 import { getWorkspacePaths } from "../update-versions/getWorkspacePaths.mjs";
+import { updateVersions } from "../update-versions/updateVersions.mjs";
 import { addBuildMetadataVersionSuffix } from "./addBuildMetadataVersionSuffix.mjs";
 import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
 import { updatePackageJsonVersion } from "./updatePackageJsonVersion.mjs";
@@ -17,3 +19,5 @@ await updatePackageJsonVersion(workspacePaths, version);
 await addPreReleaseVersionSuffix(workspacePaths, prereleaseTag);
 
 await addBuildMetadataVersionSuffix(workspacePaths, buildMetadata);
+
+updateVersions(getDepToCurrentVersionHash());

--- a/scripts/prepare-artifacts/node.mjs
+++ b/scripts/prepare-artifacts/node.mjs
@@ -5,6 +5,7 @@ import { addBuildMetadataVersionSuffix } from "./addBuildMetadataVersionSuffix.m
 import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
 import { deleteFilesWithExtension } from "./deleteFilesWithExtension.mjs";
 import { deleteNotNodeEntriesInPackageJson } from "./deleteNotNodeEntriesInPackageJson.mjs";
+import { updateFilesInPackageJson } from "./updateFilesInPackageJson.mjs";
 import { updatePackageJsonVersion } from "./updatePackageJsonVersion.mjs";
 
 const workspacePaths = getWorkspacePaths();
@@ -28,3 +29,5 @@ await deleteNotNodeEntriesInPackageJson(workspacePaths);
 
 await deleteFilesWithExtension(workspacePaths, "dist-cjs", "*.browser.js");
 await deleteFilesWithExtension(workspacePaths, "dist-cjs", "*.native.js");
+
+await updateFilesInPackageJson(workspacePaths, ["dist-cjs"]);

--- a/scripts/prepare-artifacts/node.mjs
+++ b/scripts/prepare-artifacts/node.mjs
@@ -1,9 +1,15 @@
 import { getWorkspacePaths } from "../update-versions/getWorkspacePaths.mjs";
+import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
 import { updatePackageJsonVersion } from "./updatePackageJsonVersion.mjs";
 
 const workspacePaths = getWorkspacePaths();
+const prereleaseTag = "test";
 
-// TODO: Bumping version will be done by lerna in prod version of this test.
+// TODO: Bumping version will be done by lerna in prod version of this test script.
 // We're bumping just to have same version for all packages.
 const version = process.argv[process.argv.length - 1].replace("v", "");
 await updatePackageJsonVersion(workspacePaths, version);
+
+// TODO: Adding prerelease version will not be required in prod version of this test script.
+// The prerelease version is being added to that it doesn't interfere with stable versions.
+await addPreReleaseVersionSuffix(workspacePaths, prereleaseTag);

--- a/scripts/prepare-artifacts/node.mjs
+++ b/scripts/prepare-artifacts/node.mjs
@@ -1,4 +1,9 @@
 import { getWorkspacePaths } from "../update-versions/getWorkspacePaths.mjs";
+import { updatePackageJsonVersion } from "./updatePackageJsonVersion.mjs";
 
 const workspacePaths = getWorkspacePaths();
-console.log({ workspacePaths });
+
+// TODO: Bumping version will be done by lerna in prod version of this test.
+// We're bumping just to have same version for all packages.
+const version = process.argv[process.argv.length - 1].replace("v", "");
+await updatePackageJsonVersion(workspacePaths, version);

--- a/scripts/prepare-artifacts/node.mjs
+++ b/scripts/prepare-artifacts/node.mjs
@@ -4,6 +4,7 @@ import { updateVersions } from "../update-versions/updateVersions.mjs";
 import { addBuildMetadataVersionSuffix } from "./addBuildMetadataVersionSuffix.mjs";
 import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
 import { deleteFilesWithExtension } from "./deleteFilesWithExtension.mjs";
+import { deleteNotNodeDeps } from "./deleteNotNodeDeps.mjs";
 import { deleteNotNodeEntriesInPackageJson } from "./deleteNotNodeEntriesInPackageJson.mjs";
 import { updateFilesInPackageJson } from "./updateFilesInPackageJson.mjs";
 import { updatePackageJsonVersion } from "./updatePackageJsonVersion.mjs";
@@ -31,3 +32,5 @@ await deleteFilesWithExtension(workspacePaths, "dist-cjs", "*.browser.js");
 await deleteFilesWithExtension(workspacePaths, "dist-cjs", "*.native.js");
 
 await updateFilesInPackageJson(workspacePaths, ["dist-cjs"]);
+
+await deleteNotNodeDeps(workspacePaths);

--- a/scripts/prepare-artifacts/node.mjs
+++ b/scripts/prepare-artifacts/node.mjs
@@ -1,0 +1,4 @@
+import { getWorkspacePaths } from "../update-versions/getWorkspacePaths.mjs";
+
+const workspacePaths = getWorkspacePaths();
+console.log({ workspacePaths });

--- a/scripts/prepare-artifacts/node.mjs
+++ b/scripts/prepare-artifacts/node.mjs
@@ -3,6 +3,7 @@ import { getWorkspacePaths } from "../update-versions/getWorkspacePaths.mjs";
 import { updateVersions } from "../update-versions/updateVersions.mjs";
 import { addBuildMetadataVersionSuffix } from "./addBuildMetadataVersionSuffix.mjs";
 import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
+import { deleteFilesWithExtension } from "./deleteFilesWithExtension.mjs";
 import { deleteNotNodeEntriesInPackageJson } from "./deleteNotNodeEntriesInPackageJson.mjs";
 import { updatePackageJsonVersion } from "./updatePackageJsonVersion.mjs";
 
@@ -24,3 +25,6 @@ await addBuildMetadataVersionSuffix(workspacePaths, buildMetadata);
 updateVersions(getDepToCurrentVersionHash());
 
 await deleteNotNodeEntriesInPackageJson(workspacePaths);
+
+await deleteFilesWithExtension(workspacePaths, "dist-cjs", "*.browser.js");
+await deleteFilesWithExtension(workspacePaths, "dist-cjs", "*.native.js");

--- a/scripts/prepare-artifacts/node.mjs
+++ b/scripts/prepare-artifacts/node.mjs
@@ -1,9 +1,11 @@
 import { getWorkspacePaths } from "../update-versions/getWorkspacePaths.mjs";
+import { addBuildMetadataVersionSuffix } from "./addBuildMetadataVersionSuffix.mjs";
 import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
 import { updatePackageJsonVersion } from "./updatePackageJsonVersion.mjs";
 
 const workspacePaths = getWorkspacePaths();
 const prereleaseTag = "test";
+const buildMetadata = "node-cjs";
 
 // TODO: Bumping version will be done by lerna in prod version of this test script.
 // We're bumping just to have same version for all packages.
@@ -13,3 +15,5 @@ await updatePackageJsonVersion(workspacePaths, version);
 // TODO: Adding prerelease version will not be required in prod version of this test script.
 // The prerelease version is being added to that it doesn't interfere with stable versions.
 await addPreReleaseVersionSuffix(workspacePaths, prereleaseTag);
+
+await addBuildMetadataVersionSuffix(workspacePaths, buildMetadata);

--- a/scripts/prepare-artifacts/updateFilesInPackageJson.mjs
+++ b/scripts/prepare-artifacts/updateFilesInPackageJson.mjs
@@ -1,0 +1,12 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const updateFilesInPackageJson = async (workspacePaths, filesEntry) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    const updatedPackageJson = { ...packageJson, files: filesEntry };
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-artifacts/updatePackageJsonVersion.mjs
+++ b/scripts/prepare-artifacts/updatePackageJsonVersion.mjs
@@ -1,0 +1,12 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const updatePackageJsonVersion = async (workspacePaths, version) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    const updatedPackageJson = { ...packageJson, version };
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};


### PR DESCRIPTION
### Issue
Internal JS-3092

### Description
Adds script to prepare node artifacts for publishing

### Testing
Ran the command `yarn prepare:artifacts:node v3.51.0` and verified that
* Version in package.json is changed to `3.51.0-test+node-cjs`
* All internal dependencies has `3.51.0-test+node-cjs` defined.
* The entries "types", "module", "browser" and "react-native" are removed from package.json
* The "files" entry in package.json only contains `["dist-cjs"]`
* The browser dependencies are removed from dependencies
* The dist-cjs folder doesn't contain runtimeConfig.browser.js or runtimeConfig.native.js

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
