### PR TITLE
chore(scripts): add command publish:artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "generate:defaults-mode-provider": "./scripts/generate-defaults-mode-provider/index.js",
     "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --no-private --yes",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
+    "publish:artifacts": "node --es-module-specifier-resolution=node ./scripts/publish/index.mjs",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",
     "test:e2e": "yarn build:e2e && node ./tests/e2e/index.js",
     "test:functional": "jest --config tests/functional/jest.config.js",

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -1,0 +1,15 @@
+import { exec } from "child_process";
+import { basename } from "path";
+import { promisify } from "util";
+
+import { getWorkspacePaths } from "../update-versions/getWorkspacePaths.mjs";
+
+const execPromise = promisify(exec);
+const workspacePaths = getWorkspacePaths().filter((workspacePath) => !basename(workspacePath).startsWith("aws-"));
+
+for (const workspacePath of workspacePaths) {
+  // https://docs.npmjs.com/adding-dist-tags-to-packages
+  const npmPublishCommand = `npm publish --tag test`;
+  console.log({ npmPublishCommand, cwd: workspacePath });
+  await execPromise(npmPublishCommand, { cwd: workspacePath });
+}


### PR DESCRIPTION
### Issue
Internal JS-3092

### Description
Temporary script to publish all packages except the private ones

### Testing
Output of console.log without running npm publish: [output.txt](https://github.com/trivikr/aws-sdk-js-v3/files/8028879/output.txt)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
