### PR TITLE
chore(scripts): add command publish:artifacts with tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --yes",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
     "prepare:artifacts:cjs": "node --es-module-specifier-resolution=node ./scripts/prepare-artifacts/cjs.mjs",
+    "publish:artifacts": "node --es-module-specifier-resolution=node ./scripts/publish/index.mjs",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",
     "test:e2e": "yarn build:e2e && node ./tests/e2e/index.js",
     "test:functional": "jest --config tests/functional/jest.config.js",

--- a/scripts/prepare-artifacts/test.mjs
+++ b/scripts/prepare-artifacts/test.mjs
@@ -1,0 +1,5 @@
+import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
+import { renameOrgInPackageName } from "./renameOrgInPackageName.mjs";
+
+const workspacePaths = getWorkspacePaths();
+await renameOrgInPackageName(workspacePaths, "@trivikr-test");

--- a/scripts/prepare-artifacts/test.mjs
+++ b/scripts/prepare-artifacts/test.mjs
@@ -1,5 +1,0 @@
-import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
-import { renameOrgInPackageName } from "./renameOrgInPackageName.mjs";
-
-const workspacePaths = getWorkspacePaths();
-await renameOrgInPackageName(workspacePaths, "@trivikr-test");

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -1,0 +1,15 @@
+import { exec } from "child_process";
+import { basename } from "path";
+import { promisify } from "util";
+
+import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
+
+const execPromise = promisify(exec);
+const workspacePaths = getWorkspacePaths().filter((workspacePath) => !basename(workspacePath).startsWith("aws-"));
+
+for (const workspacePath of workspacePaths) {
+  // https://docs.npmjs.com/adding-dist-tags-to-packages
+  const npmPublishCommand = `npm publish --tag cjs`;
+  console.log({ npmPublishCommand, cwd: workspacePath });
+  await execPromise(npmPublishCommand, { cwd: workspacePath });
+}

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -8,6 +8,8 @@ import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
 const execPromise = promisify(exec);
 const workspacePaths = getWorkspacePaths().filter((workspacePath) => !basename(workspacePath).startsWith("aws-"));
 
+// All workspaces need to be published just once.
+// The release automation should publish only the changed workspaces.
 for (const workspacePath of workspacePaths) {
   const packageJsonPath = join(workspacePath, "package.json");
   const packageJsonBuffer = await readFile(packageJsonPath);

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -18,5 +18,14 @@ for (const workspacePath of workspacePaths) {
 
   // https://docs.npmjs.com/adding-dist-tags-to-packages
   const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;
-  await execPromise(npmPublishCommand, { cwd: workspacePath });
+  // npm token is set in ~/.npmrc
+  const response = await execPromise(npmPublishCommand, {
+    cwd: workspacePath,
+    env: {
+      npm_config_registry: "https://registry.npmjs.org/",
+      npm_config_access: "public",
+      PATH: process.env.PATH,
+    },
+  });
+  console.log(response);
 }

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -1,5 +1,6 @@
 import { exec } from "child_process";
-import { basename } from "path";
+import { readFile } from "fs/promises";
+import { basename, join } from "path";
 import { promisify } from "util";
 
 import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
@@ -8,8 +9,12 @@ const execPromise = promisify(exec);
 const workspacePaths = getWorkspacePaths().filter((workspacePath) => !basename(workspacePath).startsWith("aws-"));
 
 for (const workspacePath of workspacePaths) {
+  const packageJsonPath = join(workspacePath, "package.json");
+  const packageJsonBuffer = await readFile(packageJsonPath);
+  const { version } = JSON.parse(packageJsonBuffer.toString());
+  const tag = version.substring(version.indexOf("+") + 1);
+
   // https://docs.npmjs.com/adding-dist-tags-to-packages
-  const npmPublishCommand = `npm publish --tag cjs`;
-  console.log({ npmPublishCommand, cwd: workspacePath });
+  const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;
   await execPromise(npmPublishCommand, { cwd: workspacePath });
 }

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -14,7 +14,7 @@ for (const workspacePath of workspacePaths) {
   const packageJsonPath = join(workspacePath, "package.json");
   const packageJsonBuffer = await readFile(packageJsonPath);
   const { version } = JSON.parse(packageJsonBuffer.toString());
-  const tag = version.substring(version.indexOf("+") + 1);
+  const tag = version.indexOf("+") > -1 ? version.substring(version.indexOf("+") + 1) : undefined;
 
   // https://docs.npmjs.com/adding-dist-tags-to-packages
   const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;


### PR DESCRIPTION
### Issue
Internal JS-3092

### Description
Temporary script to publish all packages except the private ones

### Testing

npm publish was successful for package versions `v3.52.0` in `@trivikr-test/` repo.
Example version: https://www.npmjs.com/package/@trivikr-test/client-s3

The npm publish with build metadata failed when attempted with `yarn prepare:artifacts:cjs`

<details>
<summary>diff</summary>

```console
$ git diff clients/client-accessanalyzer/package.json | head -n 15
diff --git a/clients/client-accessanalyzer/package.json b/clients/client-accessanalyzer/package.json
index 402bc4cf98..309468f1cb 100644
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@aws-sdk/client-accessanalyzer",
+  "name": "@trivikr-test/client-accessanalyzer",
   "description": "AWS SDK for JavaScript Accessanalyzer Client for Node.js, Browser and React Native",
-  "version": "3.52.0",
+  "version": "3.52.0+cjs",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
```

</details>

<details>
<summary>npm log</summary>

```console
verbose stack HttpErrorGeneral: 403 Forbidden - PUT https://registry.npmjs.org/@trivikr-test%2fclient-accessanalyzer - You cannot publish over the previously published versions: 3.52.0.
```

Detailed log: [2022-02-22T20_42_09_999Z-debug-0.log](https://github.com/trivikr/aws-sdk-js-v3/files/8120092/2022-02-22T20_42_09_999Z-debug-0.log)

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
