### PR TITLE
fix(scripts): update org in deps and devDeps too

### DIFF
--- a/scripts/prepare-artifacts/renameOrgInPackageName.mjs
+++ b/scripts/prepare-artifacts/renameOrgInPackageName.mjs
@@ -1,12 +1,23 @@
 import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 
+const renameOrgInDeps = (obj, orgName) =>
+  Object.fromEntries(Object.entries(obj).map(([key, value]) => [key.replace("@aws-sdk", orgName), value]));
+
 export const renameOrgInPackageName = async (workspacePaths, orgName) => {
   for (const workspacePath of workspacePaths) {
     const packageJsonPath = join(workspacePath, "package.json");
     const packageJsonBuffer = await readFile(packageJsonPath);
     const packageJson = JSON.parse(packageJsonBuffer.toString());
-    const updatedPackageJson = { ...packageJson, name: packageJson.name.replace("@aws-sdk", orgName) };
+
+    const { name, dependencies, devDependencies } = packageJson;
+    const updatedPackageJson = {
+      ...packageJson,
+      name: name.replace("@aws-sdk", orgName),
+      ...(dependencies && { dependencies: renameOrgInDeps(dependencies, orgName) }),
+      ...(devDependencies && { devDependencies: renameOrgInDeps(devDependencies, orgName) }),
+    };
+
     await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
   }
 };


### PR DESCRIPTION
### Issue
Follow-up for fix in https://github.com/trivikr/aws-sdk-js-v3/pull/290

### Description
Updates org in deps and devDeps too.

### Testing

```console
$ git diff
...
   "dependencies": {
-    "@aws-crypto/sha256-browser": "2.0.0",
     "@aws-crypto/sha256-js": "2.0.0",
-    "@aws-sdk/client-sts": "*",
-    "@aws-sdk/config-resolver": "*",
-    "@aws-sdk/credential-provider-node": "*",
...
+    "@trivikr-test/client-sts": "3.52.0+cjs",
+    "@trivikr-test/config-resolver": "3.52.0+cjs",
+    "@trivikr-test/credential-provider-node": "3.52.0+cjs",
+    "@trivikr-test/fetch-http-handler": "3.52.0+cjs",
...
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
