### PR TITLE
fix(scripts): add prerelease instead of build metadata

### DIFF
--- a/scripts/prepare-artifacts/addPreReleaseVersionSuffix.mjs
+++ b/scripts/prepare-artifacts/addPreReleaseVersionSuffix.mjs
@@ -1,12 +1,12 @@
 import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 
-export const addBuildMetadataVersionSuffix = async (workspacePaths, buildMetadata) => {
+export const addPreReleaseVersionSuffix = async (workspacePaths, prerelease) => {
   for (const workspacePath of workspacePaths) {
     const packageJsonPath = join(workspacePath, "package.json");
     const packageJsonBuffer = await readFile(packageJsonPath);
     const packageJson = JSON.parse(packageJsonBuffer.toString());
-    const updatedPackageJson = { ...packageJson, version: `${packageJson.version}+${buildMetadata}` };
+    const updatedPackageJson = { ...packageJson, version: `${packageJson.version}-${prerelease}` };
     await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
   }
 };

--- a/scripts/prepare-artifacts/cjs.mjs
+++ b/scripts/prepare-artifacts/cjs.mjs
@@ -1,7 +1,7 @@
 import { getDepToCurrentVersionHash } from "../update-versions/getDepToCurrentVersionHash.mjs";
 import { updateVersions } from "../update-versions/updateVersions.mjs";
 import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
-import { addBuildMetadataVersionSuffix } from "./addBuildMetadataVersionSuffix.mjs";
+import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
 import { deleteFilesWithExtension } from "./deleteFilesWithExtension.mjs";
 import { deleteNotNodeDeps } from "./deleteNotNodeDeps.mjs";
 import { deleteNotNodeEntriesInPackageJson } from "./deleteNotNodeEntriesInPackageJson.mjs";
@@ -11,9 +11,9 @@ import { updateFilesInPackageJson } from "./updateFilesInPackageJson.mjs";
 // In release automation, the steps need to be run for all workspace just once.
 // After that the steps needs to be only for the packages which need to be published.
 const workspacePaths = getWorkspacePaths();
-const buildMetadata = "cjs";
+const prerelease = "latest.cjs";
 
-await addBuildMetadataVersionSuffix(workspacePaths, buildMetadata);
+await addPreReleaseVersionSuffix(workspacePaths, prerelease);
 
 updateVersions(getDepToCurrentVersionHash());
 


### PR DESCRIPTION
### Issue
Internal JS-3092
npm doesn't allow publishing with build metadata as attempted in https://github.com/trivikr/aws-sdk-js-v3/pull/291

### Description
Adds prerelease instead of build metadata in `prepare:artifacts:cjs`

### Testing

Verified that prerelease is added instead of build metadata.

```console
$ git diff | head -n 15
diff --git a/clients/client-accessanalyzer/package.json b/clients/client-accessanalyzer/package.json
index 402bc4cf98..598d9ad2b7 100644
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@aws-sdk/client-accessanalyzer",
+  "name": "@trivikr-test/client-accessanalyzer",
   "description": "AWS SDK for JavaScript Accessanalyzer Client for Node.js, Browser and React Native",
-  "version": "3.52.0",
+  "version": "3.52.0-latest.cjs",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -12,47 +12,39 @@
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
