### PR TITLE
fix(scripts): compute npm tag from semver prerelease

### DIFF
--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -14,7 +14,7 @@ for (const workspacePath of workspacePaths) {
   const packageJsonPath = join(workspacePath, "package.json");
   const packageJsonBuffer = await readFile(packageJsonPath);
   const { version } = JSON.parse(packageJsonBuffer.toString());
-  const tag = version.indexOf("+") > -1 ? version.substring(version.indexOf("+") + 1) : undefined;
+  const tag = version.indexOf("-") > -1 ? version.substring(version.indexOf("-") + 1) : undefined;
 
   // https://docs.npmjs.com/adding-dist-tags-to-packages
   const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;


### PR DESCRIPTION
### Issue
* Internal JS-3092
* npm doesn't allow publishing with build metadata as attempted in https://github.com/trivikr/aws-sdk-js-v3/pull/291
* prerelease tag was populated instead of build metadata in https://github.com/trivikr/aws-sdk-js-v3/pull/293

### Description
Computes npm tag from semver prerelease.

### Testing
Performed npm publish for `@trivikr-test/` org by running `prepare:artifacts:cjs` before `publish:artifacts`

Example published version: [`@trivikr-test/client-s3@3.52.0-latest.cjs`](https://www.npmjs.com/package/@trivikr-test/client-s3/v/3.52.0-latest.cjs) has tag `latest.cjs`

```console
$ npm view @trivikr-test/client-s3 | tail -n5
dist-tags:
latest.cjs: 3.52.0-latest.cjs
latest: 3.52.0

published an hour ago by trivikr <trivikr.dev@gmail.com>
```

The respective packages are installed when dist-tags are specified:
* latest by default.
```console
$ yarn add @trivikr-test/client-s3
...
info Direct dependencies
└─ @trivikr-test/client-s3@3.52.0
info All dependencies
├─ @aws-crypto/crc32@2.0.0
├─ @aws-crypto/ie11-detection@2.0.0
├─ @aws-crypto/supports-web-crypto@2.0.0
├─ @aws-sdk/util-locate-window@3.52.0
├─ @trivikr-test/chunked-blob-reader-native@3.52.0
├─ @trivikr-test/chunked-blob-reader@3.52.0
├─ @trivikr-test/client-s3@3.52.0
├─ @trivikr-test/client-sso@3.52.0
├─ @trivikr-test/client-sts@3.52.0
├─ @trivikr-test/credential-provider-ini@3.52.0
├─ @trivikr-test/credential-provider-process@3.52.0
├─ @trivikr-test/eventstream-serde-browser@3.52.0
├─ @trivikr-test/eventstream-serde-config-resolver@3.52.0
├─ @trivikr-test/eventstream-serde-node@3.52.0
├─ @trivikr-test/hash-blob-browser@3.52.0
├─ @trivikr-test/hash-stream-node@3.52.0
├─ @trivikr-test/md5-js@3.52.0
├─ @trivikr-test/middleware-apply-body-checksum@3.52.0
├─ @trivikr-test/middleware-bucket-endpoint@3.52.0
├─ @trivikr-test/middleware-expect-continue@3.52.0
├─ @trivikr-test/middleware-header-default@3.52.0
├─ @trivikr-test/middleware-location-constraint@3.52.0
├─ @trivikr-test/middleware-sdk-s3@3.52.0
├─ @trivikr-test/middleware-sdk-sts@3.52.0
├─ @trivikr-test/middleware-ssec@3.52.0
├─ @trivikr-test/querystring-parser@3.52.0
├─ @trivikr-test/service-error-classification@3.52.0
├─ @trivikr-test/util-waiter@3.52.0
├─ @trivikr-test/xml-builder@3.52.0
└─ uuid@8.3.2
```
* latest when `latest` is explicitly specified.
```console
$ yarn add @trivikr-test/client-s3@latest
...
info Direct dependencies
└─ @trivikr-test/client-s3@3.52.0
info All dependencies
├─ @aws-crypto/crc32@2.0.0
├─ @aws-crypto/ie11-detection@2.0.0
├─ @aws-crypto/supports-web-crypto@2.0.0
├─ @aws-sdk/util-locate-window@3.52.0
├─ @trivikr-test/chunked-blob-reader-native@3.52.0
├─ @trivikr-test/chunked-blob-reader@3.52.0
├─ @trivikr-test/client-s3@3.52.0
├─ @trivikr-test/client-sso@3.52.0
├─ @trivikr-test/client-sts@3.52.0
├─ @trivikr-test/credential-provider-ini@3.52.0
├─ @trivikr-test/credential-provider-process@3.52.0
├─ @trivikr-test/eventstream-serde-browser@3.52.0
├─ @trivikr-test/eventstream-serde-config-resolver@3.52.0
├─ @trivikr-test/eventstream-serde-node@3.52.0
├─ @trivikr-test/hash-blob-browser@3.52.0
├─ @trivikr-test/hash-stream-node@3.52.0
├─ @trivikr-test/md5-js@3.52.0
├─ @trivikr-test/middleware-apply-body-checksum@3.52.0
├─ @trivikr-test/middleware-bucket-endpoint@3.52.0
├─ @trivikr-test/middleware-expect-continue@3.52.0
├─ @trivikr-test/middleware-header-default@3.52.0
├─ @trivikr-test/middleware-location-constraint@3.52.0
├─ @trivikr-test/middleware-sdk-s3@3.52.0
├─ @trivikr-test/middleware-sdk-sts@3.52.0
├─ @trivikr-test/middleware-ssec@3.52.0
├─ @trivikr-test/querystring-parser@3.52.0
├─ @trivikr-test/service-error-classification@3.52.0
├─ @trivikr-test/util-waiter@3.52.0
├─ @trivikr-test/xml-builder@3.52.0
└─ uuid@8.3.2
```
* latest.cjs when `latest.cjs` is explicitly specified.
```console
$ yarn add @trivikr-test/client-s3@latest.cjs
...
info Direct dependencies
└─ @trivikr-test/client-s3@3.52.0-latest.cjs
info All dependencies
├─ @aws-crypto/crc32@2.0.0
├─ @aws-sdk/util-utf8-browser@3.52.0
├─ @trivikr-test/client-s3@3.52.0-latest.cjs
├─ @trivikr-test/client-sso@3.52.0-latest.cjs
├─ @trivikr-test/client-sts@3.52.0-latest.cjs
├─ @trivikr-test/credential-provider-ini@3.52.0-latest.cjs
├─ @trivikr-test/credential-provider-process@3.52.0-latest.cjs
├─ @trivikr-test/eventstream-serde-config-resolver@3.52.0-latest.cjs
├─ @trivikr-test/eventstream-serde-node@3.52.0-latest.cjs
├─ @trivikr-test/eventstream-serde-universal@3.52.0-latest.cjs
├─ @trivikr-test/hash-stream-node@3.52.0-latest.cjs
├─ @trivikr-test/md5-js@3.52.0-latest.cjs
├─ @trivikr-test/middleware-apply-body-checksum@3.52.0-latest.cjs
├─ @trivikr-test/middleware-bucket-endpoint@3.52.0-latest.cjs
├─ @trivikr-test/middleware-expect-continue@3.52.0-latest.cjs
├─ @trivikr-test/middleware-header-default@3.52.0-latest.cjs
├─ @trivikr-test/middleware-location-constraint@3.52.0-latest.cjs
├─ @trivikr-test/middleware-sdk-s3@3.52.0-latest.cjs
├─ @trivikr-test/middleware-sdk-sts@3.52.0-latest.cjs
├─ @trivikr-test/middleware-ssec@3.52.0-latest.cjs
├─ @trivikr-test/querystring-parser@3.52.0-latest.cjs
├─ @trivikr-test/service-error-classification@3.52.0-latest.cjs
├─ @trivikr-test/util-waiter@3.52.0-latest.cjs
├─ @trivikr-test/xml-builder@3.52.0-latest.cjs
└─ uuid@8.3.2
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
