### PR TITLE
chore(scripts): remove latest prefix from prerelease tag

### DIFF
--- a/scripts/prepare-artifacts/node-cjs.mjs
+++ b/scripts/prepare-artifacts/node-cjs.mjs
@@ -15,7 +15,7 @@ import { updateFilesInPackageJson } from "./updateFilesInPackageJson.mjs";
 // After that the steps needs to be only for the packages which need to be published.
 const distFolderName = "dist-cjs";
 const workspacePaths = getWorkspacePaths().filter((workspacePath) => existsSync(join(workspacePath, distFolderName)));
-const prerelease = "latest.node.cjs";
+const prerelease = "node.cjs";
 
 await addPreReleaseVersionSuffix(workspacePaths, prerelease);
 


### PR DESCRIPTION
### Issue
Internal JS-3092

### Description
Reverts `latest` prefix added in https://github.com/trivikr/aws-sdk-js-v3/pull/293
The `latest` prefix just requires extra typing for something which can be explained though documentation, and it's not needed after having discussions on [Twitter Poll](https://twitter.com/trivikram/status/1511392497976557568), and [Node.js Slackers](https://node-js.slack.com/archives/C3910A78T/p1649221590344459) channel.

### Testing
Ran `yarn prepare:artifacts:node:cjs` and verified that prerelease tag is now `node.cjs`

```console
$ git diff | head -n15
diff --git a/clients/client-accessanalyzer/package.json b/clients/client-accessanalyzer/package.json
index d335f58d89..84705597a1 100644
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@aws-sdk/client-accessanalyzer",
+  "name": "@trivikr-test/client-accessanalyzer",
   "description": "AWS SDK for JavaScript Accessanalyzer Client for Node.js, Browser and React Native",
-  "version": "3.55.0",
+  "version": "3.55.0-node.cjs",
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
@@ -12,47 +12,39 @@
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
