### PR TITLE
fix(scripts): prepare cjs artiacts only for packages which contain them

### DIFF
--- a/scripts/prepare-artifacts/node-cjs.mjs
+++ b/scripts/prepare-artifacts/node-cjs.mjs
@@ -1,3 +1,6 @@
+import { existsSync } from "fs";
+import { join } from "path";
+
 import { getDepToCurrentVersionHash } from "../update-versions/getDepToCurrentVersionHash.mjs";
 import { updateVersions } from "../update-versions/updateVersions.mjs";
 import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
@@ -10,7 +13,8 @@ import { updateFilesInPackageJson } from "./updateFilesInPackageJson.mjs";
 
 // In release automation, the steps need to be run for all workspace just once.
 // After that the steps needs to be only for the packages which need to be published.
-const workspacePaths = getWorkspacePaths();
+const distFolderName = "dist-cjs";
+const workspacePaths = getWorkspacePaths().filter((workspacePath) => existsSync(join(workspacePath, distFolderName)));
 const prerelease = "latest.node.cjs";
 
 await addPreReleaseVersionSuffix(workspacePaths, prerelease);
@@ -19,10 +23,10 @@ updateVersions(getDepToCurrentVersionHash());
 
 await deleteNotNodeEntriesInPackageJson(workspacePaths);
 
-await deleteFilesWithExtension(workspacePaths, "dist-cjs", "*.browser.js");
-await deleteFilesWithExtension(workspacePaths, "dist-cjs", "*.native.js");
+await deleteFilesWithExtension(workspacePaths, distFolderName, "*.browser.js");
+await deleteFilesWithExtension(workspacePaths, distFolderName, "*.native.js");
 
-await updateFilesInPackageJson(workspacePaths, ["dist-cjs"]);
+await updateFilesInPackageJson(workspacePaths, [distFolderName]);
 
 await deleteNotNodeDeps(workspacePaths);
 

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -1,12 +1,18 @@
 import { exec } from "child_process";
 import { readFile } from "fs/promises";
-import { basename, join } from "path";
+import { join } from "path";
 import { promisify } from "util";
 
 import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
 
 const execPromise = promisify(exec);
-const workspacePaths = getWorkspacePaths().filter((workspacePath) => !basename(workspacePath).startsWith("aws-"));
+
+const workspacePaths = getWorkspacePaths().filter((workspacePath) => {
+  const packageJsonPath = join(workspacePath, "package.json");
+  const packageJsonBuffer = await readFile(packageJsonPath);
+  const packageJson = JSON.parse(packageJsonBuffer.toString());
+  return packageJson?.private !== true && packageJson.version.indexOf("-") > -1;
+});
 
 // All workspaces need to be published just once.
 // The release automation should publish only the changed workspaces.


### PR DESCRIPTION
### Issue
Fixes: https://github.com/trivikr/aws-sdk-js-v3/issues/321

### Description
Prepare cjs artiacts only for packages which contain them

### Testing
Ran `yarn prepare:artifacts:node:cjs` and no error was thrown. The package `util-stream-browser` was skipped, and others were modified.

```console
$ git status | wc -l    
420

# This is ok, as version publish will be skipped for packages without tags in their version
$ git diff packages/util-stream-browser/*
diff --git a/packages/util-stream-browser/package.json b/packages/util-stream-browser/package.json
index c438d4dcc7..cf9a25c271 100644
--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "*",
+    "@aws-sdk/types": "3.55.0-latest.node.cjs",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
``` 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
