### PR TITLE
chore(scripts): update markdown files with remote links

### DIFF
--- a/scripts/prepare-artifacts/node-cjs.mjs
+++ b/scripts/prepare-artifacts/node-cjs.mjs
@@ -9,6 +9,7 @@ import { deleteFilesWithExtension } from "./deleteFilesWithExtension.mjs";
 import { deleteNotNodeDeps } from "./deleteNotNodeDeps.mjs";
 import { deleteNotNodeEntriesInPackageJson } from "./deleteNotNodeEntriesInPackageJson.mjs";
 import { renameOrgInPackageName } from "./renameOrgInPackageName.mjs";
+import { replaceMarkdown } from "./replaceMarkdown.mjs";
 import { updateFilesInPackageJson } from "./updateFilesInPackageJson.mjs";
 
 // In release automation, the steps need to be run for all workspace just once.
@@ -29,6 +30,7 @@ await deleteFilesWithExtension(workspacePaths, distFolderName, "*.native.js");
 await updateFilesInPackageJson(workspacePaths, [distFolderName]);
 
 await deleteNotNodeDeps(workspacePaths);
+await replaceMarkdown(workspacePaths);
 
 // Renaming org in package name is not needed in production script.
 // This is added for testing published packages with `@trivikr-test` org.

--- a/scripts/prepare-artifacts/replaceMarkdown.mjs
+++ b/scripts/prepare-artifacts/replaceMarkdown.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..", "..");
+
+export const replaceMarkdown = async (workspacePaths) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const { version } = JSON.parse(packageJsonBuffer.toString());
+    const versionWithoutTag = version.indexOf("-") > -1 ? version.substring(0, version.indexOf("-")) : version;
+
+    for (const markdownFileName of ["README.md", "CHANGELOG.md"]) {
+      const workspaceRelativePath = workspacePath.replace(rootDir, "");
+      const markdownLink = `https://github.com/aws/aws-sdk-js-v3/blob/v${versionWithoutTag}${workspaceRelativePath}/${markdownFileName}`;
+      const markdownFilePath = join(workspacePath, markdownFileName);
+      await writeFile(
+        markdownFilePath,
+        `Please refer [${markdownFileName}](${markdownLink}) for v${versionWithoutTag}.\n`
+      );
+    }
+  }
+};


### PR DESCRIPTION
### Issue
Internal JS-3092

### Description
Adds links to Markdown files belonging to default version. This reduces the publish size of packages further.

### Testing
Ran `yarn prepare:artifacts:node:cjs` and verified that CHANGELOG and README files were updated with relevant links

```console
$ yarn prepare:artifacts:node:cjs

$ git status clients/client-acm/* --porcelain
 M clients/client-acm/CHANGELOG.md
 M clients/client-acm/README.md
 M clients/client-acm/package.json

$ git diff clients/client-acm/README.md| tail
-
-This client code is generated automatically. Any modifications will be overwritten the next time the `@aws-sdk/client-acm` package is updated.
-To contribute to client you can check our [generate clients scripts](https://github.com/aws/aws-sdk-js-v3/tree/main/scripts/generate-clients).
-
-## License
-
-This SDK is distributed under the
-[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0),
-see LICENSE for more information.
+Please refer [README.md](https://github.com/aws/aws-sdk-js-v3/blob/v3.55.0/clients/client-acm/README.md) for v3.55.0.

$ git diff clients/client-acm/CHANGELOG.md| tail
-
-
-
-# 1.0.0-alpha.1 (2020-01-08)
-
-
-### Features
-
-* add client-acm ([#656](https://github.com/aws/aws-sdk-js-v3/issues/656)) ([b5a5742](https://github.com/aws/aws-sdk-js-v3/commit/b5a5742))
+Please refer [CHANGELOG.md](https://github.com/aws/aws-sdk-js-v3/blob/v3.55.0/clients/client-acm/CHANGELOG.md) for v3.55.0.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
