### PR TITLE
chore(scripts): swallow error when npm publish fails

### DIFF
--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -25,13 +25,19 @@ for (const workspacePath of workspacePaths) {
   // https://docs.npmjs.com/adding-dist-tags-to-packages
   const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;
   // npm token is set in ~/.npmrc
-  const response = await execPromise(npmPublishCommand, {
-    cwd: workspacePath,
-    env: {
-      npm_config_registry: "https://registry.npmjs.org/",
-      npm_config_access: "public",
-      PATH: process.env.PATH,
-    },
-  });
-  console.log(response);
+  try {
+    const response = await execPromise(npmPublishCommand, {
+      cwd: workspacePath,
+      env: {
+        npm_config_registry: "https://registry.npmjs.org/",
+        npm_config_access: "public",
+        PATH: process.env.PATH,
+      },
+    });
+    console.log(response);
+  } catch (error) {
+    // Swallow error as this temporary script tries to publish over existing packages.
+    // The release automation will publish only the changed workspaces.
+    console.log(error);
+  }
 }


### PR DESCRIPTION
### Issue
Internal JS-3092

### Description
The original script was written for publishing v3.52.0, which updates all packages.
We're now going to use it for publishing other versions which doesn't update all packages. Npm publish will fail in this case, but the script will continue after logging the error.

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
