### PR TITLE
fix(scripts): skip publishing of private packages and version without tags

### DIFF
--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -7,19 +7,26 @@ import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
 
 const execPromise = promisify(exec);
 
-const workspacePaths = getWorkspacePaths().filter((workspacePath) => {
-  const packageJsonPath = join(workspacePath, "package.json");
-  const packageJsonBuffer = await readFile(packageJsonPath);
-  const packageJson = JSON.parse(packageJsonBuffer.toString());
-  return packageJson?.private !== true && packageJson.version.indexOf("-") > -1;
-});
+const workspacePaths = getWorkspacePaths();
 
 // All workspaces need to be published just once.
 // The release automation should publish only the changed workspaces.
 for (const workspacePath of workspacePaths) {
   const packageJsonPath = join(workspacePath, "package.json");
   const packageJsonBuffer = await readFile(packageJsonPath);
-  const { version } = JSON.parse(packageJsonBuffer.toString());
+  const packageJson = JSON.parse(packageJsonBuffer.toString());
+  const { version } = packageJson;
+
+  // Skip publishing private packages.
+  if (packageJson?.private === true) {
+    continue;
+  }
+
+  // Comment this if block, if releasing default version while testing
+  if (version.indexOf("-") < 0) {
+    continue;
+  }
+
   const tag = version.indexOf("-") > -1 ? version.substring(version.indexOf("-") + 1) : undefined;
 
   // https://docs.npmjs.com/adding-dist-tags-to-packages


### PR DESCRIPTION
### Issue
JS-3092

### Description
Skips publishing of private packages and version without tags

### Testing
Successfully published `v3.55.0-node.cjs` in `@trivikr-test/` org.
Example: https://www.npmjs.com/package/@trivikr-test/client-s3/v/3.55.0-node.cjs

### Additional context
Updates code added in https://github.com/trivikr/aws-sdk-js-v3/pull/322

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
