### PR TITLE
feat(scripts): add script prepare:artifacts:node:cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --yes",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
     "prepare:artifacts:node:cjs": "node --es-module-specifier-resolution=node ./scripts/prepare-artifacts/node-cjs.mjs",
+    "publish:artifacts": "node --es-module-specifier-resolution=node ./scripts/publish/index.mjs",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",
     "test:e2e": "yarn build:e2e && node ./tests/e2e/index.js",
     "test:functional": "jest --config tests/functional/jest.config.js",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "generate:defaults-mode-provider": "./scripts/generate-defaults-mode-provider/index.js",
     "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --yes",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
+    "prepare:artifacts:node:cjs": "node --es-module-specifier-resolution=node ./scripts/prepare-artifacts/node-cjs.mjs",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",
     "test:e2e": "yarn build:e2e && node ./tests/e2e/index.js",
     "test:functional": "jest --config tests/functional/jest.config.js",

--- a/scripts/prepare-artifacts/addPreReleaseVersionSuffix.mjs
+++ b/scripts/prepare-artifacts/addPreReleaseVersionSuffix.mjs
@@ -1,0 +1,12 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const addPreReleaseVersionSuffix = async (workspacePaths, prerelease) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    const updatedPackageJson = { ...packageJson, version: `${packageJson.version}-${prerelease}` };
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-artifacts/deleteFilesWithExtension.mjs
+++ b/scripts/prepare-artifacts/deleteFilesWithExtension.mjs
@@ -1,0 +1,10 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execPromise = promisify(exec);
+
+export const deleteFilesWithExtension = async (workspacePaths, distFolderName, extension) => {
+  for (const workspacePath of workspacePaths) {
+    await execPromise(`find ${workspacePath}/${distFolderName} -name "${extension}" -type f -delete`);
+  }
+};

--- a/scripts/prepare-artifacts/deleteNotNodeDeps.mjs
+++ b/scripts/prepare-artifacts/deleteNotNodeDeps.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const deleteNotNodeDeps = async (workspacePaths) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    const updatedPackageJson = {
+      ...packageJson,
+      ...(packageJson.dependencies && {
+        dependencies: Object.entries(packageJson.dependencies)
+          .filter(
+            ([key, value]) =>
+              !key.endsWith("-browser") &&
+              !key.endsWith("-native") &&
+              key !== "fetch-http-handler" &&
+              key !== "chunked-blob-reader"
+          )
+          .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {}),
+      }),
+    };
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-artifacts/deleteNotNodeEntriesInPackageJson.mjs
+++ b/scripts/prepare-artifacts/deleteNotNodeEntriesInPackageJson.mjs
@@ -1,0 +1,14 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const deleteNotNodeEntriesInPackageJson = async (workspacePaths) => {
+  for (const awsDepPath of workspacePaths) {
+    const packageJsonPath = join(awsDepPath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    ["types", "module", "browser", "react-native"].forEach((keyToDelete) => {
+      delete packageJson[keyToDelete];
+    });
+    await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-artifacts/node-cjs.mjs
+++ b/scripts/prepare-artifacts/node-cjs.mjs
@@ -1,0 +1,37 @@
+import { existsSync } from "fs";
+import { join } from "path";
+
+import { getDepToCurrentVersionHash } from "../update-versions/getDepToCurrentVersionHash.mjs";
+import { updateVersions } from "../update-versions/updateVersions.mjs";
+import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
+import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
+import { deleteFilesWithExtension } from "./deleteFilesWithExtension.mjs";
+import { deleteNotNodeDeps } from "./deleteNotNodeDeps.mjs";
+import { deleteNotNodeEntriesInPackageJson } from "./deleteNotNodeEntriesInPackageJson.mjs";
+import { renameOrgInPackageName } from "./renameOrgInPackageName.mjs";
+import { replaceMarkdown } from "./replaceMarkdown.mjs";
+import { updateFilesInPackageJson } from "./updateFilesInPackageJson.mjs";
+
+// In release automation, the steps need to be run for all workspace just once.
+// After that the steps needs to be only for the packages which need to be published.
+const distFolderName = "dist-cjs";
+const workspacePaths = getWorkspacePaths().filter((workspacePath) => existsSync(join(workspacePath, distFolderName)));
+const prerelease = "node.cjs";
+
+await addPreReleaseVersionSuffix(workspacePaths, prerelease);
+
+updateVersions(getDepToCurrentVersionHash());
+
+await deleteNotNodeEntriesInPackageJson(workspacePaths);
+
+await deleteFilesWithExtension(workspacePaths, distFolderName, "*.browser.js");
+await deleteFilesWithExtension(workspacePaths, distFolderName, "*.native.js");
+
+await updateFilesInPackageJson(workspacePaths, [distFolderName]);
+
+await deleteNotNodeDeps(workspacePaths);
+await replaceMarkdown(workspacePaths);
+
+// Renaming org in package name is not needed in production script.
+// This is added for testing published packages with `@trivikr-test` org.
+await renameOrgInPackageName(workspacePaths, "@trivikr-test");

--- a/scripts/prepare-artifacts/renameOrgInPackageName.mjs
+++ b/scripts/prepare-artifacts/renameOrgInPackageName.mjs
@@ -1,0 +1,23 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+const renameOrgInDeps = (obj, orgName) =>
+  Object.fromEntries(Object.entries(obj).map(([key, value]) => [key.replace("@aws-sdk", orgName), value]));
+
+export const renameOrgInPackageName = async (workspacePaths, orgName) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+
+    const { name, dependencies, devDependencies } = packageJson;
+    const updatedPackageJson = {
+      ...packageJson,
+      name: name.replace("@aws-sdk", orgName),
+      ...(dependencies && { dependencies: renameOrgInDeps(dependencies, orgName) }),
+      ...(devDependencies && { devDependencies: renameOrgInDeps(devDependencies, orgName) }),
+    };
+
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-artifacts/replaceMarkdown.mjs
+++ b/scripts/prepare-artifacts/replaceMarkdown.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..", "..");
+
+export const replaceMarkdown = async (workspacePaths) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const { version } = JSON.parse(packageJsonBuffer.toString());
+    const versionWithoutTag = version.indexOf("-") > -1 ? version.substring(0, version.indexOf("-")) : version;
+
+    for (const markdownFileName of ["README.md", "CHANGELOG.md"]) {
+      const workspaceRelativePath = workspacePath.replace(rootDir, "");
+      const markdownLink = `https://github.com/aws/aws-sdk-js-v3/blob/v${versionWithoutTag}${workspaceRelativePath}/${markdownFileName}`;
+      const markdownFilePath = join(workspacePath, markdownFileName);
+      await writeFile(
+        markdownFilePath,
+        `Please refer [${markdownFileName}](${markdownLink}) for v${versionWithoutTag}.\n`
+      );
+    }
+  }
+};

--- a/scripts/prepare-artifacts/updateFilesInPackageJson.mjs
+++ b/scripts/prepare-artifacts/updateFilesInPackageJson.mjs
@@ -1,0 +1,12 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const updateFilesInPackageJson = async (workspacePaths, filesEntry) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    const updatedPackageJson = { ...packageJson, files: filesEntry };
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -1,0 +1,50 @@
+import { exec } from "child_process";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { promisify } from "util";
+
+import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
+
+const execPromise = promisify(exec);
+
+const workspacePaths = getWorkspacePaths();
+
+// All workspaces need to be published just once.
+// The release automation should publish only the changed workspaces.
+for (const workspacePath of workspacePaths) {
+  const packageJsonPath = join(workspacePath, "package.json");
+  const packageJsonBuffer = await readFile(packageJsonPath);
+  const packageJson = JSON.parse(packageJsonBuffer.toString());
+  const { version } = packageJson;
+
+  // Skip publishing private packages.
+  if (packageJson?.private === true) {
+    continue;
+  }
+
+  // Comment this if block, if releasing default version while testing
+  if (version.indexOf("-") < 0) {
+    continue;
+  }
+
+  const tag = version.indexOf("-") > -1 ? version.substring(version.indexOf("-") + 1) : undefined;
+
+  // https://docs.npmjs.com/adding-dist-tags-to-packages
+  const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;
+  // npm token is set in ~/.npmrc
+  try {
+    const response = await execPromise(npmPublishCommand, {
+      cwd: workspacePath,
+      env: {
+        npm_config_registry: "https://registry.npmjs.org/",
+        npm_config_access: "public",
+        PATH: process.env.PATH,
+      },
+    });
+    console.log(response);
+  } catch (error) {
+    // Swallow error as this temporary script tries to publish over existing packages.
+    // The release automation will publish only the changed workspaces.
+    console.log(error);
+  }
+}


### PR DESCRIPTION
### Issue
JS-3092

### Description
Adds script to prepare node:cjs artifacts

### Testing
Published v3.56.0 versions on `@trivikr-test/` org:
* [@trivikr-test/client-s3@3.56.0](https://www.npmjs.com/package/@trivikr-test/client-s3/v/3.56.0)
* [@trivikr-test/client-s3@3.56.0-node.cjs](https://www.npmjs.com/package/@trivikr-test/client-s3/v/3.56.0-node.cjs)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
