### PR TITLE
chore(scripts): add temporary script to publish on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "generate:esm-wrapper": "node --es-module-specifier-resolution=node ./scripts/generate-esm-wrapper/index.mjs",
     "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --yes",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
+    "publish:artifacts": "node --es-module-specifier-resolution=node ./scripts/publish/index.mjs",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",
     "test:e2e": "yarn build:e2e && node ./tests/e2e/index.js",
     "test:functional": "jest --config tests/functional/jest.config.js && lerna run test:unit --scope \"@aws-sdk/client-*\"",

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -1,0 +1,50 @@
+import { exec } from "child_process";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { promisify } from "util";
+
+import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
+
+const execPromise = promisify(exec);
+
+const workspacePaths = getWorkspacePaths();
+
+// All workspaces need to be published just once.
+// The release automation should publish only the changed workspaces.
+for (const workspacePath of workspacePaths) {
+  const packageJsonPath = join(workspacePath, "package.json");
+  const packageJsonBuffer = await readFile(packageJsonPath);
+  const packageJson = JSON.parse(packageJsonBuffer.toString());
+  const { version } = packageJson;
+
+  // Skip publishing private packages.
+  if (packageJson?.private === true) {
+    continue;
+  }
+
+  // Comment this if block, if releasing default version while testing
+  if (version.indexOf("-") < 0) {
+    continue;
+  }
+
+  const tag = version.indexOf("-") > -1 ? version.substring(version.indexOf("-") + 1) : undefined;
+
+  // https://docs.npmjs.com/adding-dist-tags-to-packages
+  const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;
+  // npm token is set in ~/.npmrc
+  try {
+    const response = await execPromise(npmPublishCommand, {
+      cwd: workspacePath,
+      env: {
+        npm_config_registry: "https://registry.npmjs.org/",
+        npm_config_access: "public",
+        PATH: process.env.PATH,
+      },
+    });
+    console.log(response);
+  } catch (error) {
+    // Swallow error as this temporary script tries to publish over existing packages.
+    // The release automation will publish only the changed workspaces.
+    console.log(error);
+  }
+}

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -9,6 +9,8 @@ const execPromise = promisify(exec);
 
 const workspacePaths = getWorkspacePaths();
 
+const npmPublishStatus = {};
+
 // All workspaces need to be published just once.
 // The release automation should publish only the changed workspaces.
 for (const workspacePath of workspacePaths) {
@@ -21,6 +23,7 @@ for (const workspacePath of workspacePaths) {
     continue;
   }
 
+  const packageNameWithVersion = `${packageJson.name}@${packageJson.version}`;
   // npm token is set in ~/.npmrc
   try {
     const response = await execPromise("npm publish", {
@@ -32,9 +35,13 @@ for (const workspacePath of workspacePaths) {
       },
     });
     console.log(response);
+    npmPublishStatus[packageNameWithVersion] = "SUCCESS";
   } catch (error) {
     // Swallow error as this temporary script tries to publish over existing packages.
     // The release automation will publish only the changed workspaces.
     console.log(error);
+    npmPublishStatus[packageNameWithVersion] = "FAILURE";
   }
 }
+
+console.log({ npmPublishStatus });

--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -15,25 +15,15 @@ for (const workspacePath of workspacePaths) {
   const packageJsonPath = join(workspacePath, "package.json");
   const packageJsonBuffer = await readFile(packageJsonPath);
   const packageJson = JSON.parse(packageJsonBuffer.toString());
-  const { version } = packageJson;
 
   // Skip publishing private packages.
   if (packageJson?.private === true) {
     continue;
   }
 
-  // Comment this if block, if releasing default version while testing
-  if (version.indexOf("-") < 0) {
-    continue;
-  }
-
-  const tag = version.indexOf("-") > -1 ? version.substring(version.indexOf("-") + 1) : undefined;
-
-  // https://docs.npmjs.com/adding-dist-tags-to-packages
-  const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;
   // npm token is set in ~/.npmrc
   try {
-    const response = await execPromise(npmPublishCommand, {
+    const response = await execPromise("npm publish", {
       cwd: workspacePath,
       env: {
         npm_config_registry: "https://registry.npmjs.org/",


### PR DESCRIPTION
### Issue
Internal JS-3203

### Description
Adds temporary script to publish on npm

### Testing
Published following versions on npm for comparison:
* Default version: [@trivikr-test/client-ssm@3.67.0](https://www.npmjs.com/package/@trivikr-test/client-ssm/v/3.67.0)
* ECMAScript version: [@trivikr-test/client-ssm-esm@3.67.0](https://www.npmjs.com/package/@trivikr-test/client-ssm-esm/v/3.67.0)

### Additional context
Modified version of [`f447f0e` (#326)](https://github.com/trivikr/aws-sdk-js-v3/pull/326/commits/f447f0ebb64eee1a62433effa4fa868b30a0efd5)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
