### PR TITLE
fix(scripts): add dot star in targets in export

### DIFF
--- a/scripts/generate-esm-wrapper/addConditionalExports.mjs
+++ b/scripts/generate-esm-wrapper/addConditionalExports.mjs
@@ -9,8 +9,8 @@ export const addConditionalExports = async (workspacePaths, distFolderName) => {
     const updatedPackageJson = {
       ...packageJson,
       exports: {
-        import: `${distFolderName}/index.mjs`,
-        require: `${distFolderName}/index.js`,
+        import: `./${distFolderName}/index.mjs`,
+        require: `./${distFolderName}/index.js`,
       },
     };
     await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));


### PR DESCRIPTION
### Issue
Internal JS-3203

### Description
The imports are failing with the following error for published package `@trivikr-test/client-dynamodb-esm`:
```console
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "dist-cjs/index.mjs" defined in the package config /local/home/trivikr/workspace/test-esm/node_modules/@trivikr-test/client-dynamodb-esm/package.json imported from /local/home/trivikr/workspace/test-esm/index.mjs; targets must start with "./"
```

This PR adds dot start to targets in export

### Testing
Ran `generate:esm-wrapper` and verified that:

* The `./` is added to targets in exports:

```console
$ git diff clients/client-accessanalyzer/package.json | tail
@@ -91,5 +91,9 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "clients/client-accessanalyzer"
+  },
+  "exports": {
+    "import": "./dist-cjs/index.mjs",
+    "require": "./dist-cjs/index.js"
   }
 }
```

* The integration tests are successful

```console
$ yarn test:integration:legacy
yarn run v1.22.18
$ cucumber-js --fail-fast
.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

150 scenarios (150 passed)
523 steps (523 passed)
1m39.656s
Done in 101.04s.
```

* Verified that file import works from `dist-cjs/index.mjs` and code is executed without any error

```js
import { DynamoDB } from "../aws-sdk-js-v3/clients/client-dynamodb/dist-cjs/index.mjs";

const client = new DynamoDB({ region: "us-west-2" });
console.log(await client.listTables({}));
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
