### PR TITLE
chore(scripts): add wrapper suffix to esm

### DIFF
--- a/scripts/generate-esm-wrapper/index.mjs
+++ b/scripts/generate-esm-wrapper/index.mjs
@@ -19,7 +19,7 @@ updateVersions(getDepToCurrentVersionHash());
 
 // The variant suffix is not needed in production script.
 // This is added for testing publishined packahes with `@trivikr-test` org.
-await addVariantSuffix(workspacePaths, "esm");
+await addVariantSuffix(workspacePaths, "esm-wrapper");
 
 // gen-esm-wrapper throws error with file import in karma-credential-loader
 const packagesToGenerateEsmWrapper = workspacePaths.filter(


### PR DESCRIPTION
### Issue
Internal JS-3203

### Description
The previous test suffix was added in https://github.com/trivikr/aws-sdk-js-v3/pull/332, and packages were published with `-esm` suffix.

The wrapper suffix was added as:
* The specific versions of previously published packages (like [@trivikr-test/client-ssm-esm@3.67.0](https://www.npmjs.com/package/@trivikr-test/client-ssm-esm/v/3.67.0)) can't be overridden on npm. We want to use them as a reference with default package version.
* The current solution uses a wrapper. There's another solution of using [Isolate State](https://nodejs.org/api/packages.html#approach-2-isolate-state) which can use different suffix.

### Testing
Ran `generate:esm-wrapper` and verified that `-esm-wrapper` suffix was added:

```console
$ git diff clients/client-accessanalyzer/package.json
--- a/clients/client-accessanalyzer/package.json
....
 {
-  "name": "@aws-sdk/client-accessanalyzer",
+  "name": "@trivikr-test/client-accessanalyzer-esm-wrapper",
   "description": "AWS SDK for JavaScript Accessanalyzer Client for Node.js, Browser and React Native",
@@ -12,47 +12,39 @@
   "dependencies": {
     "@aws-crypto/sha256-browser": "2.0.0",
     "@aws-crypto/sha256-js": "2.0.0",
-    "@aws-sdk/client-sts": "*",
-    "@aws-sdk/config-resolver": "*",
...
+    "@trivikr-test/client-sts-esm-wrapper": "3.67.0",
+    "@trivikr-test/config-resolver-esm-wrapper": "3.58.0",
...
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
