### PR TITLE
chore(scripts): add script to prepare default variants

### DIFF
--- a/scripts/prepare-variants/default.mjs
+++ b/scripts/prepare-variants/default.mjs
@@ -1,0 +1,13 @@
+// Preparing default variant for testing in `@trivikr-test` org.
+import { getDepToCurrentVersionHash } from "../update-versions/getDepToCurrentVersionHash.mjs";
+import { updateVersions } from "../update-versions/updateVersions.mjs";
+import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
+import { renameOrgInSrc } from "./renameOrgInSrc.mjs";
+import { replaceMarkdown } from "./replaceMarkdown.mjs";
+
+const workspacePaths = getWorkspacePaths();
+
+updateVersions(getDepToCurrentVersionHash());
+
+await replaceMarkdown(workspacePaths);
+renameOrgInSrc(workspacePaths, "@trivikr-test");

--- a/scripts/prepare-variants/renameOrgInSrc.mjs
+++ b/scripts/prepare-variants/renameOrgInSrc.mjs
@@ -1,0 +1,9 @@
+import { execSync } from "child_process";
+
+export const renameOrgInSrc = (workspacePaths, orgName) => {
+  for (const workspacePath of workspacePaths) {
+    for (const fileName of ["package.json", "src"]) {
+      execSync(`grep -rl @aws-sdk ${fileName} | xargs -r sed -i 's/@aws-sdk/${orgName}/g'`, { cwd: workspacePath });
+    }
+  }
+};

--- a/scripts/prepare-variants/replaceMarkdown.mjs
+++ b/scripts/prepare-variants/replaceMarkdown.mjs
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..", "..");
+
+export const replaceMarkdown = async (workspacePaths) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const { version } = JSON.parse(packageJsonBuffer.toString());
+    const versionWithoutTag = version.indexOf("-") > -1 ? version.substring(0, version.indexOf("-")) : version;
+
+    for (const markdownFileName of ["README.md", "CHANGELOG.md"]) {
+      const workspaceRelativePath = workspacePath.replace(rootDir, "");
+      const markdownLink = `https://github.com/aws/aws-sdk-js-v3/blob/v${versionWithoutTag}${workspaceRelativePath}/${markdownFileName}`;
+      const markdownFilePath = join(workspacePath, markdownFileName);
+      await writeFile(
+        markdownFilePath,
+        `Please refer [${markdownFileName}](${markdownLink}) for v${versionWithoutTag}.\n`
+      );
+    }
+  }
+};


### PR DESCRIPTION
### Issue
Part of JS-3593

### Description
Adds a script to prepare default variants to publish in `@trivikr-test/` repo.

### Testing
```console
$ node scripts/prepare-variants/default.mjs

$ cat clients/client-acm/README.md 
Please refer [README.md](https://github.com/aws/aws-sdk-js-v3/blob/v3.170.0/clients/client-acm/README.md) for v3.170.0.

$ cat clients/client-acm/CHANGELOG.md
Please refer [CHANGELOG.md](https://github.com/aws/aws-sdk-js-v3/blob/v3.170.0/clients/client-acm/CHANGELOG.md) for v3.170.0.

$ git diff packages/abort-controller/package.json 
diff --git a/packages/abort-controller/package.json b/packages/abort-controller/package.json
index e8cd9e7493..4968b1a0db 100644
--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aws-sdk/abort-controller",
+  "name": "@trivikr-test/abort-controller",
   "version": "3.170.0",
   "description": "A simple abort controller library",
   "main": "./dist-cjs/index.js",
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "*",
+    "@trivikr-test/types": "3.170.0",
     "tslib": "^2.3.1"
   },
   "engines": {
   
$ git diff packages/abort-controller/src         
diff --git a/packages/abort-controller/src/AbortController.ts b/packages/abort-controller/src/AbortController.ts
index a8eba8f7be..73e817f87a 100644
--- a/packages/abort-controller/src/AbortController.ts
+++ b/packages/abort-controller/src/AbortController.ts
@@ -1,4 +1,4 @@
-import { AbortController as IAbortController } from "@aws-sdk/types";
+import { AbortController as IAbortController } from "@trivikr-test/types";
 
 import { AbortSignal } from "./AbortSignal";
 
diff --git a/packages/abort-controller/src/AbortSignal.ts b/packages/abort-controller/src/AbortSignal.ts
index 1da2c3386b..acd857762c 100644
--- a/packages/abort-controller/src/AbortSignal.ts
+++ b/packages/abort-controller/src/AbortSignal.ts
@@ -1,4 +1,4 @@
-import { AbortHandler, AbortSignal as IAbortSignal } from "@aws-sdk/types";
+import { AbortHandler, AbortSignal as IAbortSignal } from "@trivikr-test/types";
 
 export class AbortSignal implements IAbortSignal {
   public onabort: AbortHandler | null = null;

# Need to run twice, as there's some issue with file in 'client-sso/node_modules/@types'
# because of `@trivikr-test/` org name.
$ yarn
$ yarn

$ yarn run lerna run --scope @trivikr-test/types build

$ yarn run lerna run build

$ yarn build:types:downlevel
```

### Additional context
Refs https://github.com/trivikr/aws-sdk-js-v3/pull/279

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
