### PR TITLE
chore(scripts): add script to publish artifacts

### DIFF
--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -1,0 +1,31 @@
+import { exec } from "child_process";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { promisify } from "util";
+
+import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
+
+const execPromise = promisify(exec);
+const workspacePaths = getWorkspacePaths();
+
+// All workspaces need to be published just once.
+// The release automation should publish only the changed workspaces.
+for (const workspacePath of workspacePaths) {
+  const packageJsonPath = join(workspacePath, "package.json");
+  const packageJsonBuffer = await readFile(packageJsonPath);
+  const { version } = JSON.parse(packageJsonBuffer.toString());
+  const tag = version.indexOf("+") > -1 ? version.substring(version.indexOf("+") + 1) : undefined;
+
+  // https://docs.npmjs.com/adding-dist-tags-to-packages
+  const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;
+  // npm token is set in ~/.npmrc
+  const response = await execPromise(npmPublishCommand, {
+    cwd: workspacePath,
+    env: {
+      npm_config_registry: "https://registry.npmjs.org/",
+      npm_config_access: "public",
+      PATH: process.env.PATH,
+    },
+  });
+  console.log(response);
+}


### PR DESCRIPTION
### Issue
Internal JS-3593

### Description
Adds script to publish artifacts 

### Testing
Printed publish command as follows:
```console
# npm account does not have permissions to aws-sdk packages
$ npm whoami
trivikr

$ git diff scripts 
diff --git a/scripts/publish/index.mjs b/scripts/publish/index.mjs
index f4cb621fe9..0f18b2b82b 100644
--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -18,14 +18,15 @@ for (const workspacePath of workspacePaths) {
 
   // https://docs.npmjs.com/adding-dist-tags-to-packages
   const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;
+  console.log(`Publishing ${workspacePath} with command: ${npmPublishCommand}`);
   // npm token is set in ~/.npmrc
-  const response = await execPromise(npmPublishCommand, {
-    cwd: workspacePath,
-    env: {
-      npm_config_registry: "https://registry.npmjs.org/",
-      npm_config_access: "public",
-      PATH: process.env.PATH,
-    },
-  });
-  console.log(response);
+  // const response = await execPromise(npmPublishCommand, {
+  //   cwd: workspacePath,
+  //   env: {
+  //     npm_config_registry: "https://registry.npmjs.org/",
+  //     npm_config_access: "public",
+  //     PATH: process.env.PATH,
+  //   },
+  // });
+  // console.log(response);
 }
 
 $ node scripts/publish/index.mjs
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-accessanalyzer with command: npm publish
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-account with command: npm publish
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-acm with command: npm publish
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-acm-pca with command: npm publish
...
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/private/aws-protocoltests-json-10 with command: npm publish
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/private/aws-protocoltests-query with command: npm publish
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/private/aws-protocoltests-restjson with command: npm publish
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/private/aws-protocoltests-restxml with command: npm publish
```
The instructions from https://github.com/trivikr/aws-sdk-js-v3/pull/417 will be followed to publish packages under `@trivikr-test/` repo.

### Additional context
Ref: https://github.com/trivikr/aws-sdk-js-v3/pull/291

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
