### PR TITLE
chore(scripts): update browser artifacts to esVersion

### DIFF
--- a/scripts/prepare-variants/addPreReleaseVersionSuffix.mjs
+++ b/scripts/prepare-variants/addPreReleaseVersionSuffix.mjs
@@ -1,0 +1,12 @@
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+export const addPreReleaseVersionSuffix = async (workspacePaths, prereleaseTag) => {
+  for (const workspacePath of workspacePaths) {
+    const packageJsonPath = join(workspacePath, "package.json");
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    const updatedPackageJson = { ...packageJson, version: `${packageJson.version}-${prereleaseTag}` };
+    await writeFile(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+  }
+};

--- a/scripts/prepare-variants/default.mjs
+++ b/scripts/prepare-variants/default.mjs
@@ -2,12 +2,21 @@
 import { getDepToCurrentVersionHash } from "../update-versions/getDepToCurrentVersionHash.mjs";
 import { updateVersions } from "../update-versions/updateVersions.mjs";
 import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
+import { addPreReleaseVersionSuffix } from "./addPreReleaseVersionSuffix.mjs";
 import { renameOrgInSrc } from "./renameOrgInSrc.mjs";
 import { replaceMarkdown } from "./replaceMarkdown.mjs";
+import { updateEsVersionInBrowserConfig } from "./updateEsVersionInBrowserConfig.mjs";
+
+const esVersion = process.argv[2];
 
 const workspacePaths = getWorkspacePaths();
+await replaceMarkdown(workspacePaths);
+
+if (esVersion) {
+  await addPreReleaseVersionSuffix(workspacePaths, esVersion);
+  await updateEsVersionInBrowserConfig(workspacePaths, esVersion);
+}
 
 updateVersions(getDepToCurrentVersionHash());
 
-await replaceMarkdown(workspacePaths);
 renameOrgInSrc(workspacePaths, "@trivikr-test");

--- a/scripts/prepare-variants/updateEsVersionInBrowserConfig.mjs
+++ b/scripts/prepare-variants/updateEsVersionInBrowserConfig.mjs
@@ -1,0 +1,55 @@
+import { readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..", "..");
+
+export const updateEsVersionInBrowserConfig = async (workspacePaths, esVersion) => {
+  const tsconfigPath = join(rootDir, "tsconfig.es.json");
+
+  // Update ES Version in root TSConfig
+  const tsConfigBuffer = await readFile(tsconfigPath);
+  const tsConfig = JSON.parse(tsConfigBuffer.toString());
+  const updatedTsConfig = {
+    ...tsConfig,
+    compilerOptions: {
+      ...tsConfig.compilerOptions,
+      target: esVersion,
+    },
+  };
+  await writeFile(tsconfigPath, JSON.stringify(updatedTsConfig, null, 2).concat(`\n`));
+
+  // Remove lib from package TSConfig
+  for (const workspacePath of workspacePaths) {
+    const tsconfigPath = join(workspacePath, "tsconfig.es.json");
+    const tsConfigBuffer = await readFile(tsconfigPath);
+    const tsConfig = JSON.parse(tsConfigBuffer.toString());
+    const { compilerOptions } = tsConfig;
+    const updatedTsConfig = {
+      ...tsConfig,
+      compilerOptions: {
+        ...compilerOptions,
+        ...(compilerOptions.lib && { lib: getUpdatedLib(compilerOptions.lib, esVersion) }),
+      },
+    };
+    await writeFile(tsconfigPath, JSON.stringify(updatedTsConfig, null, 2).concat(`\n`));
+  }
+};
+
+/**
+ * Remove libs equal or prior to the target ES version
+ */
+const getUpdatedLib = (lib, esVersion) =>
+  lib.filter((libEntry) => {
+    if (libEntry === "es5") {
+      return false;
+    }
+    if (!libEntry.toLowerCase().startsWith("es20")) {
+      return true;
+    }
+    const libVersion = libEntry.split(".")[0];
+    return getEsYear(libVersion) > getEsYear(esVersion);
+  });
+
+const getEsYear = (esVersion) => Number(esVersion.substring(2));


### PR DESCRIPTION
### Issue
Internal JS-3593

### Description
Add script to update browser artifacts to specific esVersion

### Testing
```console
$ node scripts/prepare-variants/default.mjs es2015

$ git diff tsconfig.es.json
diff --git a/tsconfig.es.json b/tsconfig.es.json
index 5294bf3e47..da765642af 100644
--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -4,7 +4,7 @@
     "importHelpers": true,
     "module": "esnext",
     "noEmitHelpers": true,
-    "target": "es5",
+    "target": "es2015",
     "strict": true
   }
 }

$ git diff packages/abort-controller/tsconfig.es.json
diff --git a/packages/abort-controller/tsconfig.es.json b/packages/abort-controller/tsconfig.es.json
index 27c730dfd5..531d74414c 100644
--- a/packages/abort-controller/tsconfig.es.json
+++ b/packages/abort-controller/tsconfig.es.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src",
     "stripInternal": true
   },
   "extends": "../../tsconfig.es.json",
-  "include": ["src/"]
+  "include": [
+    "src/"
+  ]
 }

$ git diff packages/abort-controller/package.json
diff --git a/packages/abort-controller/package.json b/packages/abort-controller/package.json
index e8cd9e7493..8c66fe6ebb 100644
--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@aws-sdk/abort-controller",
-  "version": "3.170.0",
+  "name": "@trivikr-test/abort-controller",
+  "version": "3.170.0-es2015",
   "description": "A simple abort controller library",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "*",
+    "@trivikr-test/types": "3.170.0-es2015",
     "tslib": "^2.3.1"
   },
   "engines": {
   
# Need to run twice, as there's some issue with file in 'client-sso/node_modules/@types'
# because of `@trivikr-test/` org name.
$ yarn
$ yarn

$ yarn run lerna run --scope @trivikr-test/types build

$ yarn run lerna run build

$ yarn build:types:downlevel
```

### Additional context
Refs: https://github.com/trivikr/aws-sdk-js-v3/pull/417

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
