### PR TITLE
chore(scripts): select tag to publish from version

### DIFF
--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -14,7 +14,7 @@ for (const workspacePath of workspacePaths) {
   const packageJsonPath = join(workspacePath, "package.json");
   const packageJsonBuffer = await readFile(packageJsonPath);
   const { version } = JSON.parse(packageJsonBuffer.toString());
-  const tag = version.indexOf("+") > -1 ? version.substring(version.indexOf("+") + 1) : undefined;
+  const tag = version.indexOf("-") > -1 ? version.substring(version.indexOf("-") + 1) : undefined;
 
   // https://docs.npmjs.com/adding-dist-tags-to-packages
   const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;


### PR DESCRIPTION
### Issue
Internal JS-3593

### Description
Selects tag to publish from version

### Testing
Took the workspace state from testing https://github.com/trivikr/aws-sdk-js-v3/pull/419
```console
# npm account does not have permissions to aws-sdk packages
$ npm whoami
trivikr

$ git diff scripts 
diff --git a/scripts/publish/index.mjs b/scripts/publish/index.mjs
index 5aacc17962..e7091abeaa 100644
--- a/scripts/publish/index.mjs
+++ b/scripts/publish/index.mjs
@@ -18,14 +18,15 @@ for (const workspacePath of workspacePaths) {
 
   // https://docs.npmjs.com/adding-dist-tags-to-packages
   const npmPublishCommand = `npm publish${tag ? ` --tag ${tag}` : ``}`;
+  console.log(`Publishing ${workspacePath} with ${npmPublishCommand}`);
   // npm token is set in ~/.npmrc
-  const response = await execPromise(npmPublishCommand, {
-    cwd: workspacePath,
-    env: {
-      npm_config_registry: "https://registry.npmjs.org/",
-      npm_config_access: "public",
-      PATH: process.env.PATH,
-    },
-  });
-  console.log(response);
+  // const response = await execPromise(npmPublishCommand, {
+  //   cwd: workspacePath,
+  //   env: {
+  //     npm_config_registry: "https://registry.npmjs.org/",
+  //     npm_config_access: "public",
+  //     PATH: process.env.PATH,
+  //   },
+  // });
+  // console.log(response);
 }
 
$ node scripts/publish/index.mjs
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-accessanalyzer with npm publish --tag es2015
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-account with npm publish --tag es2015
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-acm with npm publish --tag es2015
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-acm-pca with npm publish --tag es2015
...
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/private/aws-protocoltests-json-10 with npm publish --tag es2015
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/private/aws-protocoltests-query with npm publish --tag es2015
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/private/aws-protocoltests-restjson with npm publish --tag es2015
Publishing /local/home/trivikr/workspace/aws-sdk-js-v3/private/aws-protocoltests-restxml with npm publish --tag es2015
```

### Additional context
Refs: https://github.com/trivikr/aws-sdk-js-v3/pull/418

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
