### PR TITLE
fix(scripts): override target for client tsconfig.es.json

### DIFF
--- a/scripts/prepare-variants/updateEsVersionInBrowserConfig.mjs
+++ b/scripts/prepare-variants/updateEsVersionInBrowserConfig.mjs
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -31,6 +31,7 @@ export const updateEsVersionInBrowserConfig = async (workspacePaths, esVersion) 
       compilerOptions: {
         ...compilerOptions,
         ...(compilerOptions.lib && { lib: getUpdatedLib(compilerOptions.lib, esVersion) }),
+        ...(basename(workspacePath).startsWith("client") && { target: esVersion }),
       },
     };
     await writeFile(tsconfigPath, JSON.stringify(updatedTsConfig, null, 2).concat(`\n`));


### PR DESCRIPTION
### Issue
Internal JS-3593

### Description
The target as not overriden for tsconfig.es.json in https://github.com/trivikr/aws-sdk-js-v3/pull/419
This PR fixed it.

### Testing
```console
$ node scripts/prepare-variants/default.mjs es2015

$ git diff clients/client-sso/tsconfig.es.json 
diff --git a/clients/client-sso/tsconfig.es.json b/clients/client-sso/tsconfig.es.json
index 4c72364cd1..12b8a6721c 100644
--- a/clients/client-sso/tsconfig.es.json
+++ b/clients/client-sso/tsconfig.es.json
@@ -1,10 +1,12 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [
+      "dom"
+    ],
     "outDir": "dist-es"
   }
 }

# Need to run twice, as there's some issue with file in 'client-sso/node_modules/@types'
# because of `@trivikr-test/` org name.
$ yarn
$ yarn

$ yarn run lerna run --scope '@trivikr-test/client-sso' build:include:deps

$ head clients/client-sso/dist-es/SSO.js
import { GetRoleCredentialsCommand, } from "./commands/GetRoleCredentialsCommand";
import { ListAccountRolesCommand, } from "./commands/ListAccountRolesCommand";
import { ListAccountsCommand, } from "./commands/ListAccountsCommand";
import { LogoutCommand } from "./commands/LogoutCommand";
import { SSOClient } from "./SSOClient";
export class SSO extends SSOClient {
    getRoleCredentials(args, optionsOrCb, cb) {
        const command = new GetRoleCredentialsCommand(args);
        if (typeof optionsOrCb === "function") {
            this.send(command, optionsOrCb);
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
